### PR TITLE
feat: avoid guest app requests reach endpoints on replay mode

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,14 +27,9 @@ class MainApp extends StatelessWidget {
         StackedService.routeObserver,
       ],
       builder: (context, child) => SessionMateBuilder(
-        excludeKeysOnDataMasking: const [
-          "id",
-          "uid",
-          "token",
-          "code",
+        keysToExcludeOnDataMasking: const [
           "smallThumbnail",
           "thumbnail",
-          "body"
         ],
         minimumStartupTime: 6000,
         child: child!,

--- a/lib/src/helpers/response_filter_helper.dart
+++ b/lib/src/helpers/response_filter_helper.dart
@@ -1,0 +1,11 @@
+import 'package:session_mate_core/session_mate_core.dart';
+
+bool hasImageContentType(ResponseEvent event) {
+  if (!event.headers.containsKey('content-type')) return false;
+
+  if (!(event.headers['content-type']?.contains('image') ?? false)) {
+    return false;
+  }
+
+  return true;
+}

--- a/lib/src/http/event_tracker.dart
+++ b/lib/src/http/event_tracker.dart
@@ -32,8 +32,10 @@ class HttpEventTracker {
 
   final _interceptorService = locator<InterceptorService>();
 
+  String get uid => _uid;
+
   void onError(Exception e) {
-    _sendRequestEvent({});
+    _sendRequestEvent({}, '');
 
     _interceptorService.onEvent(
       ResponseEvent(
@@ -51,11 +53,14 @@ class HttpEventTracker {
     data = Uint8List.fromList(bytes);
   }
 
-  void sendRequestEvent(HttpHeaders headers) => _sendRequestEvent(
+  void sendRequestEvent(HttpHeaders headers, String host) => _sendRequestEvent(
         _headersToMap(headers),
+        host,
       );
 
-  void _sendRequestEvent(Map<String, String> headers) {
+  void _sendRequestEvent(Map<String, String> headers, String host) {
+    headers['host'] = host;
+
     _interceptorService.onEvent(RequestEvent(
       uid: _uid,
       url: _url,

--- a/lib/src/package_constants.dart
+++ b/lib/src/package_constants.dart
@@ -4,7 +4,15 @@ const bool kRecordUserInteractions =
     !kDebugMode || bool.fromEnvironment('RECORD_SESSION');
 const bool kForceDriverUI = bool.fromEnvironment('FORCE_DRIVER_UI');
 const bool kUseFakeData = bool.fromEnvironment('USE_FAKE_DATA');
-const bool kDisableDataMasking = bool.fromEnvironment('DISABLE_DATA_MASKING');
+
+const String kLocalServerScheme = 'http';
+const String kLocalServerHost = 'localhost';
+
+const List<String> commonKeysToExcludeOnDataMasking = [
+  'uid',
+  'id',
+  'code',
+];
 
 const double kHorizontalPadding = 10;
 const double kVerticalPadding = 30;

--- a/lib/src/services/configuration_service.dart
+++ b/lib/src/services/configuration_service.dart
@@ -1,21 +1,33 @@
+import 'package:session_mate/src/package_constants.dart';
+
 class ConfigurationService {
   bool _dataMaskingEnabled = true;
   bool get dataMaskingEnabled => _dataMaskingEnabled;
 
-  List<String> _excludeKeysOnDataMasking = const [];
-  List<String> get excludeKeysOnDataMasking => _excludeKeysOnDataMasking;
+  List<String> _keysToExcludeOnDataMasking = const [];
+  List<String> get keysToExcludeOnDataMasking => _keysToExcludeOnDataMasking;
+
+  List<String> get allKeysToExclude => [
+        ...commonKeysToExcludeOnDataMasking,
+        ..._keysToExcludeOnDataMasking,
+      ];
 
   int _minimumStartupTime = 5000;
   int get minimumStartupTime => _minimumStartupTime;
 
+  int _listeningPort = 3000;
+  int get listeningPort => _listeningPort;
+
   void setValues({
     bool? dataMaskingEnabled,
-    List<String>? excludeKeysOnDataMasking,
+    List<String>? keysToExcludeOnDataMasking,
     int? minimumStartupTime,
+    int? listeningPort,
   }) {
     _dataMaskingEnabled = dataMaskingEnabled ?? _dataMaskingEnabled;
-    _excludeKeysOnDataMasking =
-        excludeKeysOnDataMasking ?? _excludeKeysOnDataMasking;
+    _keysToExcludeOnDataMasking =
+        keysToExcludeOnDataMasking ?? _keysToExcludeOnDataMasking;
     _minimumStartupTime = minimumStartupTime ?? _minimumStartupTime;
+    _listeningPort = listeningPort ?? _listeningPort;
   }
 }

--- a/lib/src/services/data_masking_service.dart
+++ b/lib/src/services/data_masking_service.dart
@@ -37,8 +37,6 @@ class DataMaskingService {
   }
 
   dynamic handle(dynamic data) {
-    if (!_configurationService.dataMaskingEnabled) return data;
-
     if (data is String) {
       return stringSubstitution(data);
     }
@@ -67,7 +65,7 @@ class DataMaskingService {
 
     if (data is MapEntry<String, dynamic>) {
       if ((data.value is String || data.value is num) &&
-          _configurationService.excludeKeysOnDataMasking.contains(data.key)) {
+          _configurationService.allKeysToExclude.contains(data.key)) {
         return Map<String, dynamic>.fromEntries([data]);
       }
 

--- a/lib/src/services/session_recording_service.dart
+++ b/lib/src/services/session_recording_service.dart
@@ -1,7 +1,8 @@
 import 'package:session_mate/src/app/locator_setup.dart';
 import 'package:session_mate/src/app/logger.dart';
 import 'package:session_mate/src/helpers/crypto_helper.dart';
-import 'package:session_mate/src/package_constants.dart';
+import 'package:session_mate/src/helpers/response_filter_helper.dart';
+import 'package:session_mate/src/services/configuration_service.dart';
 import 'package:session_mate_core/session_mate_core.dart';
 
 import 'data_masking_service.dart';
@@ -9,19 +10,10 @@ import 'session_service.dart';
 
 class SessionRecordingService {
   final _logger = getLogger('SessionRecordingService');
+  final _configurationService = locator<ConfigurationService>();
   final _dataMaskingService = locator<DataMaskingService>();
 
   final Map<String, String> _requests = {};
-
-  bool _hasImageContentType(ResponseEvent event) {
-    if (!event.headers.containsKey('content-type')) return false;
-
-    if (!(event.headers['content-type']?.contains('image') ?? false)) {
-      return false;
-    }
-
-    return true;
-  }
 
   void handleEvent(NetworkEvent event) {
     if (event is RequestEvent) {
@@ -43,11 +35,11 @@ class SessionRecordingService {
   }
 
   bool _avoidDataMasking(ResponseEvent event) {
-    if (kDisableDataMasking) return true;
+    if (!_configurationService.dataMaskingEnabled) return true;
 
-    if (_hasImageContentType(event)) return true;
+    if (hasImageContentType(event)) return true;
 
-    // check other filters if necessary
+    // NOTE: place to add other filters if necessary
 
     return false;
   }

--- a/lib/src/services/session_replay_service.dart
+++ b/lib/src/services/session_replay_service.dart
@@ -1,52 +1,62 @@
+import 'dart:io';
+
 import 'package:session_mate/session_mate.dart';
 import 'package:session_mate/src/helpers/crypto_helper.dart';
+import 'package:session_mate/src/helpers/response_filter_helper.dart';
 import 'package:session_mate/src/package_constants.dart';
 import 'package:session_mate_core/session_mate_core.dart';
 
 class SessionReplayService {
-  final Map<String, String> _requests = {};
+  /// Stores the hash of each request
+  final Map<String, String> _requestsHashes = {};
 
-  final Map<String, NetworkEvent> _cache = {};
+  /// Stores the responses that were masked under session recording
+  final Map<String, ResponseEvent> _maskedResponses = {};
 
   NetworkEvent? _currentEvent;
 
-  bool get _isCurrentEventARequest =>
-      _currentEvent != null && _currentEvent is RequestEvent;
-
+  // TODO: use only RequestEvent here
   void handleEvent(NetworkEvent event) {
     _currentEvent = event;
     if (event is RequestEvent) {
-      _requests[event.uid] = hashEvent(event);
+      _requestsHashes[event.uid] = hashEvent(event);
     }
   }
 
   void populateCache(List<NetworkEvent> events) {
     print(
-      'SessionService - populate ${events.length} network events into cache',
+      'SessionReplayService - populate ${events.length} masked responses into cache',
     );
 
     for (var e in events) {
-      _cache[(e as ResponseEvent).uid] = e;
+      _maskedResponses[(e as ResponseEvent).uid] = e;
+    }
+  }
+
+  Future<void> handleMockRequest(HttpRequest request) async {
+    try {
+      // NOTE: what if we hash the request directly here to avoid using uid?
+
+      final response = _maskedResponses[
+          _requestsHashes[(_currentEvent as RequestEvent).uid]]!;
+
+      request.response
+        ..headers.host = response.headers['host']
+        ..write(response.body)
+        ..close();
+    } catch (e) {
+      print('$e');
     }
   }
 
   Future<List<int>> getSanitizedData(List<int> data, {String? uid}) async {
-    if (kRecordUserInteractions) return data;
+    if (kRecordUserInteractions || uid == null) return data;
 
-    while (_isCurrentEventARequest) {
-      await Future.delayed(Duration(microseconds: 100));
-    }
-
-    if (uid == null) return data;
-
-    final response = _cache[_requests[uid]] as ResponseEvent?;
+    final response = _maskedResponses[_requestsHashes[uid]];
 
     if (response == null) return data;
 
-    if (response.headers['content-type']!.contains('image')) {
-      // return globalPlaceHolder;
-      return gPlaceHolder;
-    }
+    if (hasImageContentType(response)) return gPlaceHolder;
 
     return response.body ?? data;
   }

--- a/lib/src/setup_code.dart
+++ b/lib/src/setup_code.dart
@@ -6,7 +6,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:session_mate/session_mate.dart';
 import 'package:session_mate/src/package_constants.dart';
+import 'package:session_mate/src/services/configuration_service.dart';
 import 'package:session_mate/src/services/driver_communication_service.dart';
+import 'package:session_mate/src/services/session_replay_service.dart';
 
 import 'app/locator_setup.dart';
 
@@ -37,4 +39,17 @@ Future<void> setupSessionMate() async {
   );
   // globalPlaceHolder = base64.encode(bytes.buffer.asUint8List());
   globalPlaceHolder = bytes.buffer.asUint8List();
+
+  if (!kRecordUserInteractions) {
+    HttpServer.bind(InternetAddress.loopbackIPv4, 0).then((HttpServer server) {
+      print('📻 listening on ${server.address}, port ${server.port}');
+      locator<ConfigurationService>().setValues(listeningPort: server.port);
+      server.listen((request) {
+        locator<SessionReplayService>().handleMockRequest(request);
+      });
+    });
+
+    // NOTE: perhaps we can listen to session_mate_cli to close the server,
+    // otherwise, is going to be closed when the app is killed.
+  }
 }

--- a/lib/src/widgets/session_mate_builder/session_mate_builder.dart
+++ b/lib/src/widgets/session_mate_builder/session_mate_builder.dart
@@ -7,13 +7,13 @@ import 'session_mate_builder_viewmodel.dart';
 
 class SessionMateBuilder extends StackedView<SessionMateBuilderViewModel> {
   final bool dataMaskingEnabled;
-  final List<String> excludeKeysOnDataMasking;
+  final List<String> keysToExcludeOnDataMasking;
   final int minimumStartupTime;
   final Widget child;
   const SessionMateBuilder({
     super.key,
     this.dataMaskingEnabled = true,
-    this.excludeKeysOnDataMasking = const [],
+    this.keysToExcludeOnDataMasking = const [],
     this.minimumStartupTime = 5000,
     required this.child,
   });
@@ -39,7 +39,7 @@ class SessionMateBuilder extends StackedView<SessionMateBuilderViewModel> {
   SessionMateBuilderViewModel viewModelBuilder(BuildContext context) =>
       SessionMateBuilderViewModel(
         dataMaskingEnabled: dataMaskingEnabled,
-        excludeKeysOnDataMasking: excludeKeysOnDataMasking,
+        keysToExcludeOnDataMasking: keysToExcludeOnDataMasking,
         minimumStartupTime: minimumStartupTime,
       );
 }

--- a/lib/src/widgets/session_mate_builder/session_mate_builder_viewmodel.dart
+++ b/lib/src/widgets/session_mate_builder/session_mate_builder_viewmodel.dart
@@ -4,11 +4,11 @@ import 'package:stacked/stacked.dart';
 
 class SessionMateBuilderViewModel extends BaseViewModel {
   final bool dataMaskingEnabled;
-  final List<String> excludeKeysOnDataMasking;
+  final List<String> keysToExcludeOnDataMasking;
   final int minimumStartupTime;
   SessionMateBuilderViewModel({
     this.dataMaskingEnabled = true,
-    this.excludeKeysOnDataMasking = const [],
+    this.keysToExcludeOnDataMasking = const [],
     this.minimumStartupTime = 5000,
   });
 
@@ -17,7 +17,7 @@ class SessionMateBuilderViewModel extends BaseViewModel {
   void init() {
     _configurationService.setValues(
       dataMaskingEnabled: dataMaskingEnabled,
-      excludeKeysOnDataMasking: excludeKeysOnDataMasking,
+      keysToExcludeOnDataMasking: keysToExcludeOnDataMasking,
       minimumStartupTime: minimumStartupTime,
     );
   }

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -21,6 +21,7 @@ MockConfigurationService getAndRegisterConfigurationService({
   bool dataMaskingEnabled = true,
   List<String> keysToExcludeOnDataMasking = const [],
   int minimumStartupTime = 5000,
+  int listeningPort = 3000,
 }) {
   _removeRegistrationIfExists<ConfigurationService>();
   final service = MockConfigurationService();
@@ -29,6 +30,7 @@ MockConfigurationService getAndRegisterConfigurationService({
   when(service.keysToExcludeOnDataMasking)
       .thenReturn(keysToExcludeOnDataMasking);
   when(service.minimumStartupTime).thenReturn(minimumStartupTime);
+  when(service.listeningPort).thenReturn(listeningPort);
 
   when(service.allKeysToExclude).thenReturn([
     ...commonKeysToExcludeOnDataMasking,

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:session_mate/src/app/locator_setup.dart';
+import 'package:session_mate/src/package_constants.dart';
 import 'package:session_mate/src/services/configuration_service.dart';
 import 'package:session_mate/src/services/session_recording_service.dart';
 import 'package:session_mate/src/services/session_replay_service.dart';
@@ -18,15 +19,21 @@ import 'test_helpers.mocks.dart';
 ])
 MockConfigurationService getAndRegisterConfigurationService({
   bool dataMaskingEnabled = true,
-  List<String> excludeKeysOnDataMasking = const [],
+  List<String> keysToExcludeOnDataMasking = const [],
   int minimumStartupTime = 5000,
 }) {
   _removeRegistrationIfExists<ConfigurationService>();
   final service = MockConfigurationService();
 
   when(service.dataMaskingEnabled).thenReturn(dataMaskingEnabled);
-  when(service.excludeKeysOnDataMasking).thenReturn(excludeKeysOnDataMasking);
+  when(service.keysToExcludeOnDataMasking)
+      .thenReturn(keysToExcludeOnDataMasking);
   when(service.minimumStartupTime).thenReturn(minimumStartupTime);
+
+  when(service.allKeysToExclude).thenReturn([
+    ...commonKeysToExcludeOnDataMasking,
+    ...keysToExcludeOnDataMasking,
+  ]);
 
   locator.registerSingleton<ConfigurationService>(service);
   return service;

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -4,17 +4,18 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
-import 'dart:ui' as _i11;
+import 'dart:io' as _i8;
+import 'dart:ui' as _i12;
 
-import 'package:flutter/material.dart' as _i10;
+import 'package:flutter/material.dart' as _i11;
 import 'package:logger/src/logger.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:session_mate/src/services/configuration_service.dart' as _i4;
 import 'package:session_mate/src/services/session_recording_service.dart'
     as _i5;
 import 'package:session_mate/src/services/session_replay_service.dart' as _i6;
-import 'package:session_mate/src/services/session_service.dart' as _i8;
-import 'package:session_mate/src/utils/widget_finder.dart' as _i9;
+import 'package:session_mate/src/services/session_service.dart' as _i9;
+import 'package:session_mate/src/utils/widget_finder.dart' as _i10;
 import 'package:session_mate_core/session_mate_core.dart' as _i2;
 
 // ignore_for_file: type=lint
@@ -60,8 +61,14 @@ class MockConfigurationService extends _i1.Mock
         returnValueForMissingStub: false,
       ) as bool);
   @override
-  List<String> get excludeKeysOnDataMasking => (super.noSuchMethod(
-        Invocation.getter(#excludeKeysOnDataMasking),
+  List<String> get keysToExcludeOnDataMasking => (super.noSuchMethod(
+        Invocation.getter(#keysToExcludeOnDataMasking),
+        returnValue: <String>[],
+        returnValueForMissingStub: <String>[],
+      ) as List<String>);
+  @override
+  List<String> get allKeysToExclude => (super.noSuchMethod(
+        Invocation.getter(#allKeysToExclude),
         returnValue: <String>[],
         returnValueForMissingStub: <String>[],
       ) as List<String>);
@@ -72,10 +79,17 @@ class MockConfigurationService extends _i1.Mock
         returnValueForMissingStub: 0,
       ) as int);
   @override
+  int get listeningPort => (super.noSuchMethod(
+        Invocation.getter(#listeningPort),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as int);
+  @override
   void setValues({
     bool? dataMaskingEnabled,
-    List<String>? excludeKeysOnDataMasking,
+    List<String>? keysToExcludeOnDataMasking,
     int? minimumStartupTime,
+    int? listeningPort,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -83,8 +97,9 @@ class MockConfigurationService extends _i1.Mock
           [],
           {
             #dataMaskingEnabled: dataMaskingEnabled,
-            #excludeKeysOnDataMasking: excludeKeysOnDataMasking,
+            #keysToExcludeOnDataMasking: keysToExcludeOnDataMasking,
             #minimumStartupTime: minimumStartupTime,
+            #listeningPort: listeningPort,
           },
         ),
         returnValueForMissingStub: null,
@@ -128,6 +143,16 @@ class MockSessionReplayService extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
+  _i7.Future<void> handleMockRequest(_i8.HttpRequest? request) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleMockRequest,
+          [request],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+  @override
   _i7.Future<List<int>> getSanitizedData(
     List<int>? data, {
     String? uid,
@@ -146,7 +171,7 @@ class MockSessionReplayService extends _i1.Mock
 /// A class which mocks [SessionService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSessionService extends _i1.Mock implements _i8.SessionService {
+class MockSessionService extends _i1.Mock implements _i9.SessionService {
   @override
   List<_i2.NetworkEvent> get networkEvents => (super.noSuchMethod(
         Invocation.getter(#networkEvents),
@@ -228,7 +253,7 @@ class MockSessionService extends _i1.Mock implements _i8.SessionService {
 /// A class which mocks [WidgetFinder].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockWidgetFinder extends _i1.Mock implements _i9.WidgetFinder {
+class MockWidgetFinder extends _i1.Mock implements _i10.WidgetFinder {
   @override
   _i3.Logger get log => (super.noSuchMethod(
         Invocation.getter(#log),
@@ -242,8 +267,8 @@ class MockWidgetFinder extends _i1.Mock implements _i9.WidgetFinder {
         ),
       ) as _i3.Logger);
   @override
-  _i10.TextField? getTextFieldAtPosition({
-    required _i11.Offset? position,
+  _i11.TextField? getTextFieldAtPosition({
+    required _i12.Offset? position,
     bool? verbose = false,
   }) =>
       (super.noSuchMethod(
@@ -256,5 +281,5 @@ class MockWidgetFinder extends _i1.Mock implements _i9.WidgetFinder {
           },
         ),
         returnValueForMissingStub: null,
-      ) as _i10.TextField?);
+      ) as _i11.TextField?);
 }

--- a/test/services/configuration_service_test.dart
+++ b/test/services/configuration_service_test.dart
@@ -14,7 +14,7 @@ void main() {
         final service = getService();
 
         expect(service.dataMaskingEnabled, true);
-        expect(service.excludeKeysOnDataMasking, []);
+        expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 5000);
       });
     });
@@ -25,7 +25,7 @@ void main() {
         service.setValues();
 
         expect(service.dataMaskingEnabled, true);
-        expect(service.excludeKeysOnDataMasking, []);
+        expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 5000);
       });
 
@@ -33,12 +33,12 @@ void main() {
         final service = getService();
         service.setValues(
           dataMaskingEnabled: false,
-          excludeKeysOnDataMasking: ['uid'],
+          keysToExcludeOnDataMasking: ['uid'],
           minimumStartupTime: 1000,
         );
 
         expect(service.dataMaskingEnabled, false);
-        expect(service.excludeKeysOnDataMasking, ['uid']);
+        expect(service.keysToExcludeOnDataMasking, ['uid']);
         expect(service.minimumStartupTime, 1000);
       });
 
@@ -47,19 +47,19 @@ void main() {
         service.setValues();
 
         expect(service.dataMaskingEnabled, true);
-        expect(service.excludeKeysOnDataMasking, []);
+        expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 5000);
 
         service.setValues(minimumStartupTime: 1000);
 
         expect(service.dataMaskingEnabled, true);
-        expect(service.excludeKeysOnDataMasking, []);
+        expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 1000);
 
-        service.setValues(excludeKeysOnDataMasking: ['uid', 'token']);
+        service.setValues(keysToExcludeOnDataMasking: ['token', 'headers']);
 
         expect(service.dataMaskingEnabled, true);
-        expect(service.excludeKeysOnDataMasking, ['uid', 'token']);
+        expect(service.keysToExcludeOnDataMasking, ['token', 'headers']);
         expect(service.minimumStartupTime, 1000);
       });
     });

--- a/test/services/configuration_service_test.dart
+++ b/test/services/configuration_service_test.dart
@@ -27,6 +27,7 @@ void main() {
         expect(service.dataMaskingEnabled, true);
         expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 5000);
+        expect(service.listeningPort, 3000);
       });
 
       test('When called, should set the correct values', () {
@@ -35,11 +36,13 @@ void main() {
           dataMaskingEnabled: false,
           keysToExcludeOnDataMasking: ['uid'],
           minimumStartupTime: 1000,
+          listeningPort: 5000,
         );
 
         expect(service.dataMaskingEnabled, false);
         expect(service.keysToExcludeOnDataMasking, ['uid']);
         expect(service.minimumStartupTime, 1000);
+        expect(service.listeningPort, 5000);
       });
 
       test('When called, should set the correct values', () {
@@ -49,18 +52,28 @@ void main() {
         expect(service.dataMaskingEnabled, true);
         expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 5000);
+        expect(service.listeningPort, 3000);
 
         service.setValues(minimumStartupTime: 1000);
 
         expect(service.dataMaskingEnabled, true);
         expect(service.keysToExcludeOnDataMasking, []);
         expect(service.minimumStartupTime, 1000);
+        expect(service.listeningPort, 3000);
 
         service.setValues(keysToExcludeOnDataMasking: ['token', 'headers']);
 
         expect(service.dataMaskingEnabled, true);
         expect(service.keysToExcludeOnDataMasking, ['token', 'headers']);
         expect(service.minimumStartupTime, 1000);
+        expect(service.listeningPort, 3000);
+
+        service.setValues(listeningPort: 9001);
+
+        expect(service.dataMaskingEnabled, true);
+        expect(service.keysToExcludeOnDataMasking, ['token', 'headers']);
+        expect(service.minimumStartupTime, 1000);
+        expect(service.listeningPort, 9001);
       });
     });
   });

--- a/test/services/data_masking_service_test.dart
+++ b/test/services/data_masking_service_test.dart
@@ -108,7 +108,7 @@ void main() {
           'When called with data containing excluded keys, should return the data masked correctly',
           () {
         getAndRegisterConfigurationService(
-          excludeKeysOnDataMasking: ['id', 'token', 'code'],
+          keysToExcludeOnDataMasking: ['token'],
         );
         final service = getService();
         final masked = service.handle({

--- a/test/utils/crypto_helper_test.dart
+++ b/test/utils/crypto_helper_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:session_mate/src/helpers/crypto_helper.dart';
+import 'package:session_mate_core/session_mate_core.dart';
+
+void main() {
+  group('CryptoHelperTest -', () {
+    group('hashEvent -', () {
+      test('When called, should get the correct value', () {
+        final event = RequestEvent(
+          uid: '123456',
+          url: 'rickandmortyapi.com',
+          method: 'GET',
+          headers: {
+            'user-agent': 'Dart/3.1 (dart:io)',
+            'accept-encoding': 'gzip',
+            'content-length': '0',
+            'host': 'rickandmortyapi.com',
+          },
+        );
+
+        expect(
+          hashEvent(event),
+          '0d269061640a2b2b4475dc6ab8b8c641efdcc24146af3c850c87b92d0cdc3294',
+        );
+      });
+
+      test('When called, should get the correct value', () {
+        final event = RequestEvent(
+          uid: '123456',
+          url: 'localhost',
+          method: 'GET',
+          headers: {
+            'user-agent': 'Dart/3.1 (dart:io)',
+            'accept-encoding': 'gzip',
+            'content-length': '0',
+            'host': 'localhots',
+          },
+        );
+
+        expect(
+          hashEvent(event),
+          '2fe52dda1ce1f9a27455ab7b379af1df7e07155119a2746419c04a93f4556181',
+        );
+      });
+    });
+  });
+}

--- a/test/utils/response_filter_helper_test.dart
+++ b/test/utils/response_filter_helper_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:session_mate/src/helpers/response_filter_helper.dart';
+import 'package:session_mate_core/session_mate_core.dart';
+
+void main() {
+  group('ResponseFilterHelperTest -', () {
+    group('hasImageContentType -', () {
+      test('When called, should get the correct value', () {
+        final event = ResponseEvent(
+          uid: '123456',
+          timeMs: 600,
+          code: 200,
+          headers: {},
+        );
+
+        expect(hasImageContentType(event), false);
+      });
+
+      test('When called, should get the correct value', () {
+        final event = ResponseEvent(
+          uid: '123456',
+          timeMs: 600,
+          code: 200,
+          headers: {'cache-control': 'xxxxxxx', 'transfer-encoding': 'xxxxxxx'},
+        );
+
+        expect(hasImageContentType(event), false);
+      });
+
+      test('When called, should get the correct value', () {
+        final event = ResponseEvent(
+          uid: '123456',
+          timeMs: 600,
+          code: 200,
+          headers: {
+            'cache-control': 'private',
+            'max-age': '86400',
+            'accept-ranges': 'bytes',
+            'date': 'Tue, 26 Sep 2023 14:48:48 GMT',
+            'content-length': '8316',
+            'x-frame-options': 'SAMEORIGIN',
+            'content-type': 'image/jpeg',
+            'x-xss-protection': '0',
+            'x-content-type-options': 'nosniff',
+            'server': 'Ocean Content Server',
+            'expires': 'Tue, 26 Sep 2023 14:48:48 GMT',
+          },
+        );
+
+        expect(hasImageContentType(event), true);
+      });
+
+      test('When called, should get the correct value', () {
+        final event = ResponseEvent(
+          uid: '123456',
+          timeMs: 600,
+          code: 200,
+          headers: {
+            'cache-control': 'private',
+            'content-length': '8316',
+            'content-type': 'image/webp',
+            'server': 'Ocean Content Server',
+            'expires': 'Tue, 26 Sep 2023 14:48:48 GMT',
+          },
+        );
+
+        expect(hasImageContentType(event), true);
+      });
+
+      test('When called, should get the correct value', () {
+        final event = ResponseEvent(
+          uid: '123456',
+          timeMs: 600,
+          code: 200,
+          headers: {
+            'cache-control': 'private',
+            'content-length': '8316',
+            'content-type': 'image/png',
+            'server': 'Ocean Content Server',
+            'expires': 'Tue, 26 Sep 2023 14:48:48 GMT',
+          },
+        );
+
+        expect(hasImageContentType(event), true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Removed some keys from `excludeKeysOnDataMasking` which are not specific for the guest app. Those keys are common keys for every app.
- Added `listingPort`
- Changed name of keys to exclude from Data Masking to `keysToExcludeOnDataMasking`
- Moved `hasImageContentType` to a helper
- Added option to enable or disable data masking through configuration
- Added `handleMockRequest` method to handle the request from the local server and send it back to the guest app
- Mocked request to be handled by local server

---

https://github.com/FilledStacks/session_mate/assets/1505545/e775b4d8-34d7-4f89-b699-bda049532f28


https://github.com/FilledStacks/session_mate/assets/1505545/3d1936de-3566-409f-8b72-de0dfe7f0fb4


