### PR TITLE
fix: replace real requests with mock requests

### DIFF
--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -172,9 +172,12 @@ class SessionMateHttpClient implements HttpClient {
 
     Uri? mockedUrl;
     final replaceRealRequestWithMockedRequest =
-        !kRecordUserInteractions && _driverCommunicationService.replayActive;
+        !kRecordUserInteractions && !url.host.contains('sessionmate');
+    // !kRecordUserInteractions && _driverCommunicationService.replayActive;
+
     print(
         '💙 Client | openUrl - kRecordUserInteractions:$kRecordUserInteractions replayActive: ${_driverCommunicationService.replayActive}');
+
     if (replaceRealRequestWithMockedRequest) {
       mockedUrl = url.replace(
         scheme: kLocalServerScheme,
@@ -202,8 +205,10 @@ class SessionMateHttpClient implements HttpClient {
   @override
   set connectionFactory(
           Future<ConnectionTask<Socket>> Function(
-                  Uri url, String? proxyHost, int? proxyPort)?
-              f) =>
+            Uri url,
+            String? proxyHost,
+            int? proxyPort,
+          )? f) =>
       _httpClient.connectionFactory = f;
 
   @override


### PR DESCRIPTION
The requests were still being sent to the real endpoint, outside the device. The problem was that replayActive in driverCommunicationService was not working as expected, at least that's what I understood. I changed the condition using part of the session mate backend url to avoid using a mock on any session mate request.