### PR TITLE
Feature: Unique events per screen

### DIFF
--- a/lib/src/services/driver_communication_service.dart
+++ b/lib/src/services/driver_communication_service.dart
@@ -2,12 +2,16 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:session_mate/src/app/locator_setup.dart';
+import 'package:session_mate/src/services/session_service.dart';
 import 'package:session_mate_core/session_mate_core.dart';
 import 'package:stacked/stacked.dart';
 
 enum _DriverCommunicationState { waitForReplay, replayActive, freshStart }
 
 class DriverCommunicationService with ListenableServiceMixin {
+  final _sessionService = locator<SessionService>();
+
   Completer<String>? _communicationCompleter;
 
   _DriverCommunicationState _state = _DriverCommunicationState.freshStart;
@@ -30,6 +34,7 @@ class DriverCommunicationService with ListenableServiceMixin {
     if (_wasReplayExecuted) _onReplayCompletedCallback?.call();
 
     _state = _DriverCommunicationState.waitForReplay;
+    _sessionService.clearNavigationStack();
     notifyListeners();
 
     return _communicationCompleter!.future;

--- a/lib/src/services/session_service.dart
+++ b/lib/src/services/session_service.dart
@@ -19,6 +19,8 @@ class SessionService with ListenableServiceMixin {
   final List<String> _views = [];
   List<String> get views => _views;
 
+  String get navigationStackId => _views.join('-');
+
   void addEvent(SessionEvent event) {
     final removeLastEventBeforeAdding = _checkIfLastEventShouldBeRemoved(event);
 
@@ -111,5 +113,10 @@ class SessionService with ListenableServiceMixin {
     }
 
     return false;
+  }
+
+  void clearNavigationStack() {
+    _views.clear();
+    notifyListeners();
   }
 }

--- a/lib/src/widgets/driver_ui/common/event_visual.dart
+++ b/lib/src/widgets/driver_ui/common/event_visual.dart
@@ -20,27 +20,20 @@ class EventVisual extends ViewModelWidget<DriverUIViewModel> {
     final positionX = isScrollEndIndicator
         ? event.position.x + (event as ScrollEvent).scrollDelta!.x
         : event.position.x;
+
     final positionY = isScrollEndIndicator
         ? event.position.y + (event as ScrollEvent).scrollDelta!.y
         : event.position.y;
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
-      child: viewModel.showDebugInformation
-          ? _EventVerbose(
-              index: index,
-              event: event,
-              isFinalPosition: isScrollEndIndicator,
-              x: positionX,
-              y: positionY,
-            )
-          : _EventSimple(
-              index: index,
-              event: event,
-              isFinalPosition: isScrollEndIndicator,
-              x: positionX,
-              y: positionY,
-            ),
+      child: _EventSimple(
+        index: index,
+        event: event,
+        isFinalPosition: isScrollEndIndicator,
+        x: positionX,
+        y: positionY,
+      ),
     );
   }
 }
@@ -64,20 +57,21 @@ class _EventSimple extends ViewModelWidget<DriverUIViewModel> {
     return Container(
       width: kEventVisualSize,
       height: kEventVisualSize,
+      alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: isFinalPosition
-            ? Color(event.type.alternativeColor)
-            : Color(event.type.color),
+        border: Border.all(
+          color: Color(event.type.color),
+          width: 1,
+        ),
         shape: BoxShape.circle,
       ),
-      child: Center(
-        child: Text(
-          '', //'${event.type.name.substring(0, 1).toUpperCase()}${index + 1}',
-          style: TextStyle(
-            color: Colors.black,
-            fontSize: 9,
-            fontWeight: FontWeight.w600,
-          ),
+      child: Container(
+        width: 2,
+        height: 2,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Color(event.type.color),
+          shape: BoxShape.circle,
         ),
       ),
     );

--- a/lib/src/widgets/driver_ui/driver_ui_viewmodel.dart
+++ b/lib/src/widgets/driver_ui/driver_ui_viewmodel.dart
@@ -9,6 +9,7 @@ import 'package:session_mate/src/services/hive_service.dart';
 import 'package:session_mate/src/services/http_service.dart';
 import 'package:session_mate/src/services/session_service.dart';
 import 'package:session_mate/src/utils/notification_extractor.dart';
+import 'package:session_mate/src/widgets/session_mate_route_tracker.dart';
 import 'package:session_mate_core/session_mate_core.dart';
 import 'package:stacked/stacked.dart';
 
@@ -27,6 +28,10 @@ class DriverUIViewModel extends ReactiveViewModel {
         .map(_notificationExtractor.notificationToScrollableDescription)
         .listen((notification) => viewEvents =
             _notificationExtractor.scrollEvents(notification, viewEvents));
+
+    _routeTracker.addListener(() {
+      rebuildUi();
+    });
   }
 
   final _configurationService = locator<ConfigurationService>();
@@ -34,12 +39,17 @@ class DriverUIViewModel extends ReactiveViewModel {
   final _sessionService = locator<SessionService>();
   final _hiveService = locator<HiveService>();
   final _httpService = locator<HttpService>();
+  final _routeTracker = locator<SessionMateRouteTracker>();
 
   final _notificationController = StreamController<Notification>.broadcast();
 
   ValueNotifier<List<UIEvent>> eventsNotifier = ValueNotifier([]);
 
   List<UIEvent> get viewEvents => eventsNotifier.value;
+
+  String get currentView => _routeTracker.currentRoute;
+
+  String get currentNavigationStackId => _sessionService.navigationStackId;
 
   set viewEvents(List<UIEvent> events) {
     eventsNotifier.value = events;

--- a/lib/src/widgets/driver_ui/events_visualizer.dart
+++ b/lib/src/widgets/driver_ui/events_visualizer.dart
@@ -18,8 +18,12 @@ class EventsVisualizer extends ViewModelWidget<DriverUIViewModel> {
           return Stack(
             children: [
               ...events
-                  .where((interaction) =>
-                      InteractionUtils.visibleOnScreen(interaction, size))
+                  .where(
+                      (event) => InteractionUtils.visibleOnScreen(event, size))
+                  .where((event) =>
+                      event.view == viewModel.currentView &&
+                      event.navigationStackId ==
+                          viewModel.currentNavigationStackId)
                   .map(
                     (event) => Positioned(
                       key: Key(event.automationKey),

--- a/lib/src/widgets/interaction_recorder/interaction_recorder_viewmodel.dart
+++ b/lib/src/widgets/interaction_recorder/interaction_recorder_viewmodel.dart
@@ -120,6 +120,7 @@ TextEditingController.
         capturedDeviceWidth: screenSize.width,
       ).toJson(),
       "runtimeType": type.name,
+      "navigationStackId": _sessionService.navigationStackId,
     });
 
     final scrollables = _widgetFinder.getAllScrollablesOnScreen();
@@ -146,6 +147,8 @@ TextEditingController.
         view: _routeTracker.currentRoute,
         order: _timeUtils.timestamp,
       );
+
+      _lastTapPosition = null;
     }
 
     print('🔴 ConcludeCommand - ${_activeCommand?.toJson()}');
@@ -156,7 +159,6 @@ TextEditingController.
   void _clearActiveCommand() {
     _activeCommand = null;
     _activeTextEditingController = null;
-    _lastTapPosition = null;
   }
 
   void onUserTap({
@@ -181,6 +183,7 @@ TextEditingController.
       ),
       view: _routeTracker.currentRoute,
       order: _timeUtils.timestamp,
+      navigationStackId: _sessionService.navigationStackId,
     );
 
     final scrollables = _widgetFinder.getAllScrollablesOnScreen();
@@ -297,6 +300,7 @@ TextEditingController.
           duration: _scrollTimer?.elapsedMilliseconds,
           view: _routeTracker.currentRoute,
           order: _timeUtils.timestamp,
+          navigationStackId: _sessionService.navigationStackId,
         ),
       );
 

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -16,6 +16,7 @@ import 'package:session_mate/src/utils/scroll_applicator.dart';
 import 'package:session_mate/src/utils/time_utils.dart';
 import 'package:session_mate/src/utils/widget_finder.dart';
 import 'package:session_mate/src/widgets/session_mate_route_tracker.dart';
+import 'package:session_mate_core/session_mate_core.dart';
 
 import 'test_helpers.mocks.dart';
 
@@ -61,6 +62,10 @@ MockNotificationExtractor getAndRegisterNotificationExtractor() {
 MockScrollApplicator getAndRegisterScrollApplicator() {
   _removeRegistrationIfExists<ScrollApplicator>();
   final service = MockScrollApplicator();
+
+  when(service.applyScrollableToEvent(any, any))
+      .thenReturn(TapEvent(position: EventPosition(x: 1, y: 0)));
+
   locator.registerSingleton<ScrollApplicator>(service);
   return service;
 }


### PR DESCRIPTION
You cannot tap on a widget if it's overlapped by another. Since we were adding all events on screen at the same time this was causing issues. 

I now have made sure that per view and based on the navigationStackId we show only the events required at the time that the command is going to play. 