### PR TITLE
feat: update hashEvent function

### DIFF
--- a/lib/src/helpers/crypto_helper.dart
+++ b/lib/src/helpers/crypto_helper.dart
@@ -1,14 +1,58 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:session_mate_core/session_mate_core.dart';
 
 String hashEvent(RequestEvent event) {
   return sha256
-      .convert(utf8.encode(jsonEncode(event.copyWith(
-        uid: '',
-        body: event.hasBody ? event.body : null,
-        order: 0,
-      ))))
+      .convert(utf8.encode(jsonEncode({
+        'url': prepareUrl(event.url),
+        'method': event.method,
+        'body': prepareBody(event.body),
+      })))
       .toString();
+}
+
+@visibleForTesting
+String prepareUrl(String url) {
+  final queryStarts = url.indexOf('?');
+
+  if (queryStarts == -1) return url;
+
+  final query = url.substring(queryStarts);
+  final queryParameters = query.split('&');
+
+  String modifiedQuery = '';
+  for (var param in queryParameters) {
+    final keyValue = param.split('=');
+    modifiedQuery = '$modifiedQuery${keyValue[0]}=${keyValue[1].length}';
+  }
+
+  return '${url.substring(0, queryStarts)}$modifiedQuery';
+}
+
+@visibleForTesting
+Uint8List? prepareBody(Uint8List? body) {
+  if (body == null || body.isEmpty) return null;
+
+  Map<String, dynamic> modifiedBody = {};
+  final Map<String, dynamic> data = jsonDecode(convertUint8ListToString(body));
+
+  for (var item in data.entries) {
+    modifiedBody[item.key] = item.value.toString().length;
+  }
+
+  return convertStringToUint8List(jsonEncode(modifiedBody));
+}
+
+Uint8List convertStringToUint8List(String str) {
+  final List<int> codeUnits = str.codeUnits;
+  final Uint8List unit8List = Uint8List.fromList(codeUnits);
+
+  return unit8List;
+}
+
+String convertUint8ListToString(Uint8List uint8list) {
+  return String.fromCharCodes(uint8list);
 }

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -298,6 +298,12 @@ class MockSessionService extends _i1.Mock implements _i12.SessionService {
         returnValueForMissingStub: <String>[],
       ) as List<String>);
   @override
+  String get navigationStackId => (super.noSuchMethod(
+        Invocation.getter(#navigationStackId),
+        returnValue: '',
+        returnValueForMissingStub: '',
+      ) as String);
+  @override
   int get listenersCount => (super.noSuchMethod(
         Invocation.getter(#listenersCount),
         returnValue: 0,
@@ -380,6 +386,14 @@ class MockSessionService extends _i1.Mock implements _i12.SessionService {
           ),
         ),
       ) as _i2.Session);
+  @override
+  void clearNavigationStack() => super.noSuchMethod(
+        Invocation.method(
+          #clearNavigationStack,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void listenToReactiveValues(List<dynamic>? reactiveValues) =>
       super.noSuchMethod(

--- a/test/utils/crypto_helper_test.dart
+++ b/test/utils/crypto_helper_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:session_mate/src/helpers/crypto_helper.dart';
 import 'package:session_mate_core/session_mate_core.dart';
@@ -5,42 +7,165 @@ import 'package:session_mate_core/session_mate_core.dart';
 void main() {
   group('CryptoHelperTest -', () {
     group('hashEvent -', () {
-      test('When called rickandmortyapi, should get the correct value', () {
-        final event = RequestEvent(
+      test(
+          'When called with GET method, real request and mock request should have the same hash',
+          () {
+        final realRequest = RequestEvent(
           uid: '123456',
-          url: 'rickandmortyapi.com',
+          url:
+              'https://www.googleapis.com/books/v1/volumes?q=subject%3Acomputers',
           method: 'GET',
           headers: {
             'user-agent': 'Dart/3.1 (dart:io)',
             'accept-encoding': 'gzip',
             'content-length': '0',
-            'host': 'rickandmortyapi.com',
+            'host': 'googleapis.com',
           },
+          view: '/book-details-view',
+          order: 1697131738086,
         );
 
-        expect(
-          hashEvent(event),
-          'f551e877d8f514da2ddf747a52dd14ee93a23b3a472f2e75562e81917081ec70',
+        final mockedRequest = realRequest.copyWith(
+          url:
+              'https://www.googleapis.com/books/v1/volumes?q=xxxxxxxxxxxxxxxxxxx',
         );
+
+        expect(hashEvent(realRequest), hashEvent(mockedRequest));
       });
 
-      test('When called with local host, should get the correct value', () {
-        final event = RequestEvent(
+      test(
+          'When called with GET method, real request and mock request should have the same hash',
+          () {
+        final realRequest = RequestEvent(
           uid: '123456',
-          url: 'localhost',
+          url:
+              'https://filledstacks.api?email=dane@filledstacks.com&password=1234',
           method: 'GET',
           headers: {
             'user-agent': 'Dart/3.1 (dart:io)',
             'accept-encoding': 'gzip',
             'content-length': '0',
-            'host': 'localhots',
+            'host': 'filledstacks.api',
           },
+          view: '/book-details-view',
+          order: 1697131738086,
         );
 
-        expect(
-          hashEvent(event),
-          'e3eaa3f4be8dad57cba66d67494b882af4f4365acb665f54aa991d87ed53b028',
+        final mockedRequest = realRequest.copyWith(
+          url:
+              'https://filledstacks.api?email=xxxx@xxxxxxxxxxxx.xxx&password=9999',
         );
+
+        expect(hashEvent(realRequest), hashEvent(mockedRequest));
+      });
+
+      test(
+          'When called with POST method, real request and mock request should have the same hash',
+          () {
+        final realRequest = RequestEvent(
+          uid: '123456',
+          url: 'https://filledstacks.api',
+          method: 'POST',
+          headers: {
+            'user-agent': 'Dart/3.1 (dart:io)',
+            'accept-encoding': 'gzip',
+            'content-length': '0',
+            'host': 'filledstacks.api',
+          },
+          body: convertStringToUint8List(jsonEncode({
+            'email': 'dane@filledstacks.com',
+            'password': '1234',
+          })),
+          view: '/book-details-view',
+          order: 1697131738086,
+        );
+
+        final mockedRequest = realRequest.copyWith(
+          body: convertStringToUint8List(jsonEncode({
+            'email': 'xxxx@xxxxxxxxxxxx.xxx',
+            'password': '9999',
+          })),
+        );
+
+        expect(hashEvent(realRequest), hashEvent(mockedRequest));
+      });
+    });
+
+    group('prepareBody -', () {
+      test('When called, should get the correct data', () {
+        final input = {
+          'username': 'filledstacks',
+          'password': 'session-mate',
+          'expiresInMins': 60,
+        };
+
+        final streamInput = convertStringToUint8List(jsonEncode(input));
+        final streamOutput = prepareBody(streamInput);
+
+        final output = {
+          'username': 12,
+          'password': 12,
+          'expiresInMins': 2,
+        };
+
+        expect(output, jsonDecode(convertUint8ListToString(streamOutput!)));
+      });
+
+      test('When called, should get the correct data', () {
+        final input = {
+          'username': 'xxxxxxxxxxxx',
+          'password': 'xxxxxxx-xxxx',
+          'expiresInMins': 99,
+        };
+
+        final streamInput = convertStringToUint8List(jsonEncode(input));
+        final streamOutput = prepareBody(streamInput);
+
+        final output = {
+          'username': 12,
+          'password': 12,
+          'expiresInMins': 2,
+        };
+
+        expect(output, jsonDecode(convertUint8ListToString(streamOutput!)));
+      });
+
+      test('When called, should get the correct data', () {
+        final input = {
+          'username': 'dane.mackier@filledstacks.com',
+          'password': 'session-mate',
+          'expiresInMins': 3600,
+        };
+
+        final streamInput = convertStringToUint8List(jsonEncode(input));
+        final streamOutput = prepareBody(streamInput);
+
+        final output = {
+          'username': 29,
+          'password': 12,
+          'expiresInMins': 4,
+        };
+
+        expect(output, jsonDecode(convertUint8ListToString(streamOutput!)));
+      });
+
+      test('When called, should get the correct data', () {
+        final input = {
+          'username': 'xxxx.xxxxxxx@xxxxxxxxxxxx.xxx',
+          'password': 'xxxxxxx-xxxx',
+          'expiresInMins': 9999,
+        };
+
+        final streamInput = convertStringToUint8List(jsonEncode(input));
+        final streamOutput = prepareBody(streamInput);
+
+        final output = {
+          'username': 29,
+          'password': 12,
+          'expiresInMins': 4,
+        };
+
+        expect(output, jsonDecode(convertUint8ListToString(streamOutput!)));
       });
     });
   });


### PR DESCRIPTION
Updated `hashEvent` function to support masked query and masked body on requests.

**NOTE**
You need to remove the last [commit](8b27edb8a6d1873ff41ab536963f79a0cf9f4b37) from yesterday on main branch because we don't need that fix anymore, mock responses now works with random images 🔥 , was a problem of the hash.