### PR TITLE
feat: allow disable session mate completely

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,7 +19,6 @@ Future<void> main() async {
   setupDialogUi();
   setupBottomSheetUi();
   runApp(const SessionMate(child: MainApp()));
-  // runApp(const MainApp());
 }
 
 class MainApp extends StatelessWidget {

--- a/lib/src/services/configuration_service.dart
+++ b/lib/src/services/configuration_service.dart
@@ -31,6 +31,9 @@ class ConfigurationService {
   bool _logNetworkData = false;
   bool get logNetworkData => _logNetworkData;
 
+  bool _enabled = true;
+  bool get enabled => _enabled;
+
   void setValues({
     bool? dataMaskingEnabled,
     List<String>? keysToExcludeOnDataMasking,
@@ -39,6 +42,7 @@ class ConfigurationService {
     String? apiKey,
     bool? logNetworkData,
     bool? verboseLogs,
+    bool? enabled,
   }) {
     _dataMaskingEnabled = dataMaskingEnabled ?? _dataMaskingEnabled;
     _keysToExcludeOnDataMasking =
@@ -47,6 +51,7 @@ class ConfigurationService {
     _listeningPort = listeningPort ?? _listeningPort;
     _apiKey = apiKey;
     _logNetworkData = logNetworkData ?? _logNetworkData;
-    _verboseLogs = verboseLogs ?? false;
+    _verboseLogs = verboseLogs ?? _verboseLogs;
+    _enabled = enabled ?? _enabled;
   }
 }

--- a/lib/src/session_mate_utils.dart
+++ b/lib/src/session_mate_utils.dart
@@ -1,5 +1,6 @@
 import 'package:session_mate/src/app/locator_setup.dart';
 import 'package:session_mate/src/package_constants.dart';
+import 'package:session_mate/src/services/configuration_service.dart';
 import 'package:session_mate/src/services/hive_service.dart';
 import 'package:session_mate/src/services/session_service.dart';
 import 'package:session_mate_core/session_mate_core.dart';
@@ -12,11 +13,13 @@ class SessionMateUtils {
     Object? exception,
     StackTrace? stackTrace,
   }) async {
+    if (!locator<ConfigurationService>().enabled) return;
+
+    if (!kRecordUserInteractions) return;
+
     final sessionService = locator<SessionService>();
     final localStorageService = locator<HiveService>();
     final httpService = locator<HttpService>();
-
-    if (!kRecordUserInteractions) return;
 
     try {
       if (kLocalOnlyUsage) {
@@ -33,7 +36,7 @@ class SessionMateUtils {
         );
       }
     } catch (e) {
-      print(e);
+      print('🔴 Error:${e.toString()}');
     }
   }
 }

--- a/lib/src/setup_code.dart
+++ b/lib/src/setup_code.dart
@@ -9,6 +9,7 @@ import 'package:session_mate/src/package_constants.dart';
 import 'package:session_mate/src/services/configuration_service.dart';
 import 'package:session_mate/src/services/driver_communication_service.dart';
 import 'package:session_mate/src/services/session_replay_service.dart';
+import 'package:session_mate/src/widgets/session_mate_route_tracker.dart';
 
 import 'app/locator_setup.dart';
 
@@ -18,7 +19,14 @@ final gPlaceHolder = base64Decode(
 
 late Uint8List globalPlaceHolder;
 
-Future<void> setupSessionMate() async {
+Future<void> setupSessionMate({bool enabled = true}) async {
+  if (!enabled) {
+    locator.registerLazySingleton(() => ConfigurationService());
+    locator.registerLazySingleton(() => SessionMateRouteTracker.instance);
+    locator<ConfigurationService>().setValues(enabled: enabled);
+    return;
+  }
+
   if (kRecordUserInteractions) {
     WidgetsFlutterBinding.ensureInitialized();
   } else if (kReplaySession) {

--- a/lib/src/utils/widget_finder.dart
+++ b/lib/src/utils/widget_finder.dart
@@ -67,7 +67,8 @@ class WidgetFinder {
 
       if (textField.controller == null) {
         log.e(
-            'SESSION MATE ERROR: TextField in the UI tree has no controller. This means we cannot record your input events');
+          'SESSION MATE ERROR: TextField in the UI tree has no controller. This means we cannot record your input events',
+        );
       }
 
       return (textField.controller ?? TextEditingController(), textFieldRect);

--- a/lib/src/widgets/session_mate.dart
+++ b/lib/src/widgets/session_mate.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:session_mate/src/app/locator_setup.dart';
+import 'package:session_mate/src/services/configuration_service.dart';
 
 class SessionMate extends StatefulWidget {
   final Widget child;
@@ -23,6 +25,8 @@ class _SessionMateState extends State<SessionMate> {
 
   @override
   Widget build(BuildContext context) {
+    if (!locator<ConfigurationService>().enabled) return widget.child;
+
     return KeyedSubtree(key: key, child: widget.child);
   }
 }

--- a/lib/src/widgets/session_mate_builder/session_mate_builder.dart
+++ b/lib/src/widgets/session_mate_builder/session_mate_builder.dart
@@ -33,6 +33,8 @@ class SessionMateBuilder extends StackedView<SessionMateBuilderViewModel> {
     // ignore: avoid_renaming_method_parameters
     Widget? _,
   ) {
+    if (!viewModel.enabled) return child;
+
     return kRecordUserInteractions
         ? InteractionRecorder(child: child)
         : DriverUI(child: child);

--- a/lib/src/widgets/session_mate_builder/session_mate_builder_viewmodel.dart
+++ b/lib/src/widgets/session_mate_builder/session_mate_builder_viewmodel.dart
@@ -21,6 +21,8 @@ class SessionMateBuilderViewModel extends BaseViewModel {
 
   final _configurationService = locator<ConfigurationService>();
 
+  bool get enabled => _configurationService.enabled;
+
   void init() {
     _configurationService.setValues(
       apiKey: apiKey,

--- a/lib/src/widgets/session_mate_navigator_observer.dart
+++ b/lib/src/widgets/session_mate_navigator_observer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:session_mate/src/app/locator_setup.dart';
+import 'package:session_mate/src/services/configuration_service.dart';
 
 import 'session_mate_route_tracker.dart';
 
@@ -8,23 +9,30 @@ class SessionMateNavigatorObserver extends NavigatorObserver {
 
   static final instance = SessionMateNavigatorObserver._();
 
-  final routeTracker = locator<SessionMateRouteTracker>();
+  final _configurationService = locator<ConfigurationService>();
+  final _routeTracker = locator<SessionMateRouteTracker>();
 
   @override
   void didPop(Route route, Route? previousRoute) {
-    routeTracker.setCurrentRoute(_getRouteName(previousRoute));
+    if (!_configurationService.enabled) return;
+
+    _routeTracker.setCurrentRoute(_getRouteName(previousRoute));
     super.didPop(route, previousRoute);
   }
 
   @override
   void didPush(Route route, Route? previousRoute) {
-    routeTracker.setCurrentRoute(_getRouteName(route));
+    if (!_configurationService.enabled) return;
+
+    _routeTracker.setCurrentRoute(_getRouteName(route));
     super.didPush(route, previousRoute);
   }
 
   @override
   void didReplace({Route? newRoute, Route? oldRoute}) {
-    routeTracker.setCurrentRoute(_getRouteName(newRoute));
+    if (!_configurationService.enabled) return;
+
+    _routeTracker.setCurrentRoute(_getRouteName(newRoute));
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
   }
 
@@ -34,7 +42,9 @@ class SessionMateNavigatorObserver extends NavigatorObserver {
     required int index,
     required String viewName,
   }) {
-    routeTracker.changeRouteIndex(viewName, index);
+    if (!_configurationService.enabled) return;
+
+    _routeTracker.changeRouteIndex(viewName, index);
   }
 
   String _getRouteName(Route? route) {

--- a/lib/src/widgets/session_mate_route_tracker.dart
+++ b/lib/src/widgets/session_mate_route_tracker.dart
@@ -10,7 +10,6 @@ class SessionMateRouteTracker extends ChangeNotifier {
   static final instance = SessionMateRouteTracker._();
 
   final _logger = getLogger('SessionMateRouteTracker');
-  final _sessionService = locator<SessionService>();
 
   @visibleForTesting
   bool testMode = false;
@@ -43,8 +42,8 @@ class SessionMateRouteTracker extends ChangeNotifier {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setRoute(route);
-      _sessionService.addView(route);
-      _sessionService.checkForEnterPressed('Navigation');
+      locator<SessionService>().addView(route);
+      locator<SessionService>().checkForEnterPressed('Navigation');
       notifyListeners();
     });
   }


### PR DESCRIPTION
**PROPOSAL**

This approach allows the user to disable Session Mate completely from the main function of the host application with just one line, as below. I think it has value because the developer can easily disable Session Mate and use their application as usual and then can re-enable without having to remove any settings beyond the enabled property, everything else stays in place. Aka, when disabled there will be no extra resources tracking activity of the app.

`await setupSessionMate(enabled: false);`