### PR TITLE
fix: update onDragEnd method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4
+
+- Update `onDragEnd` method to avoid doing anything when dragRecorder is NOT recording.
+
 ## 0.7.3
 
 - Update regular expression for special characters

--- a/lib/src/widgets/interaction_recorder/interaction_recorder_viewmodel.dart
+++ b/lib/src/widgets/interaction_recorder/interaction_recorder_viewmodel.dart
@@ -219,6 +219,8 @@ class InteractionRecorderViewModel extends BaseViewModel {
   }
 
   void onDragEnd(Offset position) {
+    if (!_dragRecorder.isRecording) return;
+
     final dragEvent = _dragRecorder.completeDragEvent(
       endPosition: EventPosition(
         capturedDeviceHeight: _currentScreenSize.height,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: session_mate
 description: Instantly reproduce bugs with a single click, directly from your app.
-version: 0.7.3
+version: 0.7.4
 homepage: https://sessionmate.dev/
 
 environment:

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -48,9 +48,13 @@ import 'test_helpers.mocks.dart';
     onMissingStub: OnMissingStub.returnDefault,
   ),
 ])
-MockDragRecorder getAndRegisterDragRecorder() {
+MockDragRecorder getAndRegisterDragRecorder({
+  bool isRecording = false,
+}) {
   _removeRegistrationIfExists<DragRecorder>();
   final service = MockDragRecorder();
+
+  when(service.isRecording).thenReturn(isRecording);
   locator.registerSingleton<DragRecorder>(service);
   return service;
 }

--- a/test/viewmodels/interaction_recorder_viewmodel_test.dart
+++ b/test/viewmodels/interaction_recorder_viewmodel_test.dart
@@ -124,5 +124,30 @@ void main() {
         );
       });
     });
+
+    group('onDragEnd -', () {
+      test('When dragRecorder is NOT recording should NOT do anything', () {
+        final dragRecorder = getAndRegisterDragRecorder();
+        final model = _getModel();
+
+        model.onDragEnd(Offset(-1, 1));
+
+        verify(dragRecorder.isRecording).called(1);
+      });
+
+      test('When dragRecorder is recording should call completeDragEvent', () {
+        final dragRecorder = getAndRegisterDragRecorder(isRecording: true);
+        final sessionService = getAndRegisterSessionService();
+        final model = _getModel();
+
+        model.onDragEnd(Offset(-1, 1));
+
+        verify(dragRecorder.isRecording);
+        verify(
+          dragRecorder.completeDragEvent(endPosition: anyNamed('endPosition')),
+        );
+        verify(sessionService.addEvent(any));
+      });
+    });
   });
 }


### PR DESCRIPTION
Updated `onDragEnd` method to avoid doing anything when dragRecorder is NOT recording.